### PR TITLE
Added add_rosteritem, delete_rosteritem and get_roster commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,15 @@ Usage
     # Set nickname
     client.set_nickname(user='bob', host='example.com', nickname='Bob the builder')
 
+    # Get Bob's contacts
+    client.get_roster(user='bob', host='example.com')
+
+    # Add Alice to Bob's contact group Friends
+    client.add_rosteritem(localuser='bob', localserver='example.com', user='alice', server='example.com', nick='Alice from Wonderland', group='Friends', subs='both')
+
+    # Delete Alice from Bob's contact group Friends
+    client.delete_rosteritem(localuser='bob', localserver='example.com', user='alice', server='example.com')
+
     # Get list of *all* connected users
     client.connected_users()
 

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ Usage
     # Add Alice to Bob's contact group Friends
     client.add_rosteritem(localuser='bob', localserver='example.com', user='alice', server='example.com', nick='Alice from Wonderland', group='Friends', subs='both')
 
-    # Delete Alice from Bob's contact group Friends
+    # Delete Alice from Bob's contacts
     client.delete_rosteritem(localuser='bob', localserver='example.com', user='alice', server='example.com')
 
     # Get list of *all* connected users

--- a/src/pyejabberd/client.py
+++ b/src/pyejabberd/client.py
@@ -361,7 +361,10 @@ class EjabberdAPIClient(contract.EjabberdAPIContract):
         :type subs: str|unicode
         :return:
         """
-        return self._call_api(definitions.AddRosterItem, localuser=localuser, localserver=localserver, user=user, server=server, nick=nick, group=group, subs=subs)
+        return self._call_api(definitions.AddRosterItem,
+                              localuser=localuser, localserver=localserver,
+                              user=user, server=server,
+                              nick=nick, group=group, subs=subs)
 
     def delete_rosteritem(self, localuser, localserver, user, server):
         """
@@ -391,7 +394,6 @@ class EjabberdAPIClient(contract.EjabberdAPIContract):
         :return: A list of user's contacts
         """
         return self._call_api(definitions.GetRoster, user=user, host=host)
-
 
     def _validate_and_serialize_arguments(self, api, arguments):
         """

--- a/src/pyejabberd/client.py
+++ b/src/pyejabberd/client.py
@@ -343,13 +343,13 @@ class EjabberdAPIClient(contract.EjabberdAPIContract):
 
     def add_rosteritem(self, localuser, localserver, user, server, nick, group, subs):
         """
-        Add an item to a user's roster (supports ODBC)
-        localuser localserver user server nick group subs
+        Add an item to a user's roster
+
         :param localuser: The username of user we are going to add a contact to
         :type localuser: str|unicode
         :param localserver: The XMPP_DOMAIN
         :type localserver: str|unicode
-        :param user: The contact we are going to add to the local user's roster
+        :param user: The contact we are going to add to the user's roster
         :type user: str|unicode
         :param server: The XMPP_DOMAIN
         :type server: str|unicode
@@ -365,12 +365,13 @@ class EjabberdAPIClient(contract.EjabberdAPIContract):
 
     def delete_rosteritem(self, localuser, localserver, user, server):
         """
-        Delete an item from a user's roster (supports ODBC)
+        Delete an item from a user's roster
+
         :param localuser: The username of user we are going to delete a contact from
         :type localuser: str|unicode
         :param localserver: The XMPP_DOMAIN
         :type localserver: str|unicode
-        :param user: The contact we are going to delete from the local user's roster
+        :param user: The contact we are going to delete from the user's roster
         :type user: str|unicode
         :param server: The XMPP_DOMAIN
         :type server: str|unicode
@@ -380,13 +381,14 @@ class EjabberdAPIClient(contract.EjabberdAPIContract):
 
     def get_roster(self, user, host):
         """
-        Get roster of a local user
-        :param user: The username for the user we want info for
+        Get roster of a user
+
+        :param user: The username of the user we want contact information for
         :type user: str|unicode
         :param host: The XMPP_DOMAIN
         :type host: str|unicode
         :rtype: Iterable
-        :return: A list of registered users in the xmpp_host
+        :return: A list of user's contacts
         """
         return self._call_api(definitions.GetRoster, user=user, host=host)
 

--- a/src/pyejabberd/client.py
+++ b/src/pyejabberd/client.py
@@ -341,6 +341,56 @@ class EjabberdAPIClient(contract.EjabberdAPIContract):
         """
         return self._call_api(definitions.GetRoomAffiliations, name=name, service=service)
 
+    def add_rosteritem(self, localuser, localserver, user, server, nick, group, subs):
+        """
+        Add an item to a user's roster (supports ODBC)
+        localuser localserver user server nick group subs
+        :param localuser: The username of user we are going to add a contact to
+        :type localuser: str|unicode
+        :param localserver: The XMPP_DOMAIN
+        :type localserver: str|unicode
+        :param user: The contact we are going to add to the local user's roster
+        :type user: str|unicode
+        :param server: The XMPP_DOMAIN
+        :type server: str|unicode
+        :param nick: Nickname of the contact
+        :type nick: str|unicode
+        :param group: To what contact group the contact goes to
+        :type group: str|unicode
+        :param subs: The type of subscription
+        :type subs: str|unicode
+        :return:
+        """
+        return self._call_api(definitions.AddRosterItem, localuser=localuser, localserver=localserver, user=user, server=server, nick=nick, group=group, subs=subs)
+
+    def delete_rosteritem(self, localuser, localserver, user, server):
+        """
+        Delete an item from a user's roster (supports ODBC)
+        :param localuser: The username of user we are going to delete a contact from
+        :type localuser: str|unicode
+        :param localserver: The XMPP_DOMAIN
+        :type localserver: str|unicode
+        :param user: The contact we are going to delete from the local user's roster
+        :type user: str|unicode
+        :param server: The XMPP_DOMAIN
+        :type server: str|unicode
+        :return:
+        """
+        return self._call_api(definitions.DeleteRosterItem, localuser=localuser, localserver=localserver, user=user, server=server)
+
+    def get_roster(self, user, host):
+        """
+        Get roster of a local user
+        :param user: The username for the user we want info for
+        :type user: str|unicode
+        :param host: The XMPP_DOMAIN
+        :type host: str|unicode
+        :rtype: Iterable
+        :return: A list of registered users in the xmpp_host
+        """
+        return self._call_api(definitions.GetRoster, user=user, host=host)
+
+
     def _validate_and_serialize_arguments(self, api, arguments):
         """
         Internal method to validate and serialize arguments

--- a/src/pyejabberd/contract.py
+++ b/src/pyejabberd/contract.py
@@ -76,3 +76,15 @@ class EjabberdAPIContract(with_metaclass(ABCMeta, object)):  # pragma: no cover
     @abstractmethod
     def get_room_affiliations(self, name, service):
         pass
+
+    @abstractmethod
+    def add_rosteritem(self, localuser, localserver, user, server, nick, group, subs):
+        pass
+
+    @abstractmethod
+    def delete_rosteritem(self, localuser, localserver, user, server):
+        pass
+
+    @abstractmethod
+    def get_roster(self, user, host):
+        pass

--- a/src/pyejabberd/definitions.py
+++ b/src/pyejabberd/definitions.py
@@ -193,3 +193,30 @@ class GetRoomAffiliations(API):
             'affiliation': Affiliation.get_by_name(subdict['affiliation'][2]['affiliation']),
             'reason': subdict['affiliation'][3]['reason'],
         } for subdict in affiliations]
+
+
+class AddRosterItem(API):
+    method = 'add_rosteritem'
+    arguments = [StringArgument('localuser'), StringArgument('localserver'), 
+                 StringArgument('user'), StringArgument('server'), 
+                 StringArgument('nick'), StringArgument('group'), StringArgument('subs')]
+
+    def transform_response(self, api, arguments, response):
+        return response.get('res') == 0
+
+
+class DeleteRosterItem(API):
+    method = 'delete_rosteritem'
+    arguments = [StringArgument('localuser'), StringArgument('localserver'), 
+                 StringArgument('user'), StringArgument('server')]
+
+    def transform_response(self, api, arguments, response):
+        return response.get('res') == 0
+
+
+class GetRoster(API):
+    method = 'get_roster'
+    arguments = [StringArgument('user'), StringArgument('host')]
+
+    def transform_response(self, api, arguments, response):
+        return response.get('roster')

--- a/src/pyejabberd/definitions.py
+++ b/src/pyejabberd/definitions.py
@@ -197,8 +197,8 @@ class GetRoomAffiliations(API):
 
 class AddRosterItem(API):
     method = 'add_rosteritem'
-    arguments = [StringArgument('localuser'), StringArgument('localserver'), 
-                 StringArgument('user'), StringArgument('server'), 
+    arguments = [StringArgument('localuser'), StringArgument('localserver'),
+                 StringArgument('user'), StringArgument('server'),
                  StringArgument('nick'), StringArgument('group'), StringArgument('subs')]
 
     def transform_response(self, api, arguments, response):
@@ -207,7 +207,7 @@ class AddRosterItem(API):
 
 class DeleteRosterItem(API):
     method = 'delete_rosteritem'
-    arguments = [StringArgument('localuser'), StringArgument('localserver'), 
+    arguments = [StringArgument('localuser'), StringArgument('localserver'),
                  StringArgument('user'), StringArgument('server')]
 
     def transform_response(self, api, arguments, response):
@@ -223,7 +223,7 @@ class GetRoster(API):
         for contact in response.get('contacts', []):
             contact_details = {}
             for parameter in contact['contact']:
-                for key,value in parameter.items():
+                for key, value in parameter.items():
                     contact_details[key] = value
             roster.append(contact_details)
         return roster

--- a/src/pyejabberd/definitions.py
+++ b/src/pyejabberd/definitions.py
@@ -219,4 +219,4 @@ class GetRoster(API):
     arguments = [StringArgument('user'), StringArgument('host')]
 
     def transform_response(self, api, arguments, response):
-        return response.get('roster')
+        return response.get('contacts')

--- a/src/pyejabberd/definitions.py
+++ b/src/pyejabberd/definitions.py
@@ -219,4 +219,11 @@ class GetRoster(API):
     arguments = [StringArgument('user'), StringArgument('host')]
 
     def transform_response(self, api, arguments, response):
-        return response.get('contacts')
+        roster = []
+        for contact in response.get('contacts', []):
+            contact_details = {}
+            for parameter in contact['contact']:
+                for key,value in parameter.items():
+                    contact_details[key] = value
+            roster.append(contact_details)
+        return roster

--- a/tests/test_pyejabberd.py
+++ b/tests/test_pyejabberd.py
@@ -415,8 +415,18 @@ class EjabberdAPITests(TestCase):
 
     def test_roster_commands(self):
         # create test users
-        create_test_user(self.api, 'testuser_15', host=XMPP_DOMAIN)
-        create_test_user(self.api, 'testuser_16', host=XMPP_DOMAIN)
+        try:
+            user1_created = create_test_user(self.api, 'testuser_15', host=XMPP_DOMAIN)
+        except UserAlreadyRegisteredError:
+            user1_created = False
+        try:
+            user2_created = create_test_user(self.api, 'testuser_16', host=XMPP_DOMAIN)
+        except UserAlreadyRegisteredError:
+            user2_created = False
+        # if users already exist delete the second user from the first user's roster
+        if user1_created == False and user2_created == False:
+            delete_rosteritem = self.api.delete_rosteritem('testuser_15', XMPP_DOMAIN, 'testuser_16', XMPP_DOMAIN)
+            self.assertTrue(delete_rosteritem)
         # check if the first user's roster is empty
         roster = self.api.get_roster('testuser_15', XMPP_DOMAIN)
         self.assertEqual(roster, [])
@@ -425,14 +435,14 @@ class EjabberdAPITests(TestCase):
         self.assertTrue(add_rosteritem)
         # check if the first user's roster contains the second user
         roster = self.api.get_roster('testuser_15', XMPP_DOMAIN)
-        self.assertEqual(roster[0]['jid'], 'testuser_16@{}'.format(XMPP_DOMAIN))
+        self.assertEqual(roster[0]['jid'], 'testuser_16@{0}'.format(XMPP_DOMAIN))
         self.assertEqual(roster[0]['group'], 'buddies')
         # add the second user to the first user's roster again, now to a different group
         add_rosteritem = self.api.add_rosteritem('testuser_15', XMPP_DOMAIN, 'testuser_16', XMPP_DOMAIN, 'testuser_16', 'friends', 'both')
         self.assertTrue(add_rosteritem)
         # check if the first user's roster contains the second user in the different group
         roster = self.api.get_roster('testuser_15', XMPP_DOMAIN)
-        self.assertEqual(roster[0]['jid'], 'testuser_16@{}'.format(XMPP_DOMAIN))
+        self.assertEqual(roster[0]['jid'], 'testuser_16@{0}'.format(XMPP_DOMAIN))
         self.assertEqual(roster[0]['group'], 'friends')
         # delete the second user from the first user's roster
         delete_rosteritem = self.api.delete_rosteritem('testuser_15', XMPP_DOMAIN, 'testuser_16', XMPP_DOMAIN)

--- a/tests/test_pyejabberd.py
+++ b/tests/test_pyejabberd.py
@@ -413,6 +413,34 @@ class EjabberdAPITests(TestCase):
                                 output_affiliations = self.api.get_room_affiliations(room, service=MUC_SERVICE)
                                 self.assertEqual(len(output_affiliations), 0)
 
+    def test_roster_commands(self):
+        # create test users
+        create_test_user(self.api, 'testuser_15', host=XMPP_DOMAIN)
+        create_test_user(self.api, 'testuser_16', host=XMPP_DOMAIN)
+        # check if the first user's roster is empty
+        roster = self.api.get_roster('testuser_15', XMPP_DOMAIN)
+        self.assertEqual(roster, [])
+        # add the second user to the first user's roster
+        add_rosteritem = self.api.add_rosteritem('testuser_15', XMPP_DOMAIN, 'testuser_16', XMPP_DOMAIN, 'testuser_16', 'buddies', 'both')
+        self.assertTrue(add_rosteritem)
+        # check if the first user's roster contains the second user
+        roster = self.api.get_roster('testuser_15', XMPP_DOMAIN)
+        self.assertEqual(roster[0]['jid'], 'testuser_16@{}'.format(XMPP_DOMAIN))
+        self.assertEqual(roster[0]['group'], 'buddies')
+        # add the second user to the first user's roster again, now to a different group
+        add_rosteritem = self.api.add_rosteritem('testuser_15', XMPP_DOMAIN, 'testuser_16', XMPP_DOMAIN, 'testuser_16', 'friends', 'both')
+        self.assertTrue(add_rosteritem)
+        # check if the first user's roster contains the second user in the different group
+        roster = self.api.get_roster('testuser_15', XMPP_DOMAIN)
+        self.assertEqual(roster[0]['jid'], 'testuser_16@{}'.format(XMPP_DOMAIN))
+        self.assertEqual(roster[0]['group'], 'friends')
+        # delete the second user from the first user's roster
+        delete_rosteritem = self.api.delete_rosteritem('testuser_15', XMPP_DOMAIN, 'testuser_16', XMPP_DOMAIN)
+        self.assertTrue(delete_rosteritem)
+        # check if the first user's roster is empty
+        roster = self.api.get_roster('testuser_15', XMPP_DOMAIN)
+        self.assertEqual(roster, [])
+
 
 class LibraryTests(TestCase):
     def test_string_argument(self):


### PR DESCRIPTION
The pull request contains three new commands for roster management.

The following roster management commands are available in Ejabberd's mod_admin_extra module:

add_rosteritem - add an item to user's roster
delete_rosteritem - delete an item from user's roster
get_roster - retrieve user's roster

README contains example usage of the new commands.

Tests passed using modified tox.ini to test the new commands on Ejabberd 15.07 using Python 2.7.9
