### PR TITLE
Remove enum34 as Python>3.4 has it as standard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 six==1.9.0
-enum34==1.1.2
 future==0.15.2
 unittest2==1.1.0


### PR DESCRIPTION
Remove enum34 as Python>3.4 has it as standard